### PR TITLE
Changes rock base to bare

### DIFF
--- a/tests/sanity/test_pinniped.py
+++ b/tests/sanity/test_pinniped.py
@@ -33,4 +33,4 @@ def test_pinniped(version: str):
     assert EXPECTED_HELPSTR in docker_run.stdout
 
     # check rock filesystem
-    docker_util.ensure_image_contains_paths(rock.image, EXPECTED_FILES)
+    docker_util.ensure_image_contains_paths_bare(rock.image, EXPECTED_FILES)

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -40,11 +40,13 @@ commands =
     black {tox_root}/integration --check --diff
 
 [testenv:sanity]
-description = Run integration tests
+description = Run sanity tests
 deps =
     -r {tox_root}/requirements-test.txt
+allowlist_externals =
+    sudo
 commands =
-    pytest -v \
+    sudo -E {envpython} -m pytest -v \
         --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \

--- a/v0.30.0/rockcraft.yaml
+++ b/v0.30.0/rockcraft.yaml
@@ -6,8 +6,9 @@ description: >
 version: v0.30.0
 license: Apache-2.0
 
-base: ubuntu@24.04
+base: bare
 build-base: ubuntu@24.04
+run-user: _daemon_
 platforms:
   amd64:
 
@@ -19,6 +20,22 @@ services:
     startup: enabled
 
 parts:
+  add-base-packages:
+    plugin: nil
+    stage-packages:
+      # Original Dockerfile uses gcr.io/distroless/static:nonroot as a base.
+      # This image contains the following:
+      # https://github.com/GoogleContainerTools/distroless/blob/1533e54a73805ec13fe0cc68218fc7a215a0a6f7/base/README.md
+      - ca-certificates
+      - tzdata
+      - base-passwd
+
+  # Can't have stage packages and stage slices together, apparently.
+  add-base-slices:
+    plugin: nil
+    stage-packages:
+      - base-files_tmp
+
   build-deps:
     plugin: nil
     build-snaps:


### PR DESCRIPTION
Switching to a bare-based image will reduce the overall image size and reduces attack surface area.

The original Dockerfile uses ``gcr.io/distroless/static:nonroot``, which has only a few packages. We can add those packages and switch to a bare-based image. Additionally, the original image is a non-root image, thus, we should also switch our rock to be non-root.

We can no longer use ``ensure_image_contains_paths`` to check if files exist in the rock images, since they are now bare-based. Instead, we can use ``ensure_image_contains_paths_bare``, which checks the image layers instead. Because of this, we need sufficient permissions to check the ``/var/lib/docker`` folder.